### PR TITLE
Rename Kind to PackFolder

### DIFF
--- a/NuGetizer.sln
+++ b/NuGetizer.sln
@@ -6,13 +6,10 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CDF1828A-0877-4238-A218-5E4FE219F6CC}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		azure-pipelines.yml = azure-pipelines.yml
-		.github\workflows\build.yml = .github\workflows\build.yml
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
 		src\NuGet.Config = src\NuGet.Config
 		README.md = README.md
-		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetizer.Tasks", "src\NuGetizer.Tasks\NuGetizer.Tasks.csproj", "{57F59BF6-9272-4B66-98A1-334B3FDA5721}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Simple, flexible, intuitive and powerful NuGet packaging.
 
-## Why
+# Why
 
 The .NET SDK has built-in support for packing. The design of its targets, property 
 and item names it not very consistent, however. When packing non-trivial solutions 
@@ -14,7 +14,7 @@ An [alternative clean and clear design](https://github.com/NuGet/Home/wiki/NuGet
 was proposed and I got to implement the initial spec, but it never got traction 
 with the NuGet team.
 
-## What
+# What
 
 With the learnings from years of building and shipping packages of different 
 levels of complexity, as well as significant use of the SDK Pack functionality 
@@ -37,52 +37,110 @@ contents.
 Another key design choice is that any package content inference should be trivial 
 to turn off wholesale in case the heuristics don't do exactly what you need. Just set 
 `EnablePackInference=false` and you will only get explicit `PackageFile` items 
-in your package.
+in your package. This gives you ultimate control without having to understand any of the inference rules explained below. 
 
-### Package Inference
+All [inference rules are laid out in a single .targets](src/NuGetizer.Tasks/NuGetizer.Inference.targets) file that's easy to inspect them to learn more, and the file is not imported at all when `EnablePackInference=false`.
 
-Package inference provides some built-in heuristics for common scenarios so you 
-don't have to customize the packing much. It works by transforming various built-in 
+## Package Contents Inference
+
+Package content inference provides some built-in heuristics for common scenarios so you 
+don't have to customize the project much and can instead let the rules build up the contents of your package by interpreting your existing project elements. It works by transforming various built-in 
 items into corresponding `PackageFile` items, much as if you had added them by 
 hand.
 
 Inference can be turned off for specific items by just adding `Pack="false"` 
-item metadata.
+item metadata. It can also be turned off by default for all items of a given type with an item definition group:
 
-The default transformations are:
+```xml
+<ItemDefinitionGroup>
+  <PackageReference>
+    <Pack>false</Pack>
+  </PackageReference>
+</ItemDefinitionGroup>
+```
 
-| Source                                                          | Inferred                                                          | Notes                                                                                            |
-| --------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Project build output                                            | `<PackageFile Kind="$(BuildOutputKind)"/>`                        | Kind defaults to `Lib`. Includes .xml and .pdb if they are generated. (1)                        |
-| `<PackageReference ... />`                                      | `<PackageFile ... Kind="Dependency" />`                           | `PrivateAssets=all` is present, it's not added as dependency. (2)                                |
-| `<Content .../>`                                                | `<PackageFile ... Kind="content" />`                              | Regular content that's not part of the build output                                              |
-| `<Content ... CopyToOutputDirectory="PreserveNewest\|Always"/>` | `<PackageFile Include="%(TargetPath)" Kind="$(BuildOutputKind)" ` | Content that's copied to the build output is part of the primary output so it uses its kind. (3) |
-| `<None ... Pack="true" />`                                      | `<PackageFile ... Kind="none" />`                                 |                                                                                                  |
-| `<Reference ... />`                                             | `<PackageFile ... Kind="frameworkReference"`                      | Only those resolved from the target framework directory are included. (4)                        |
-|                                                                 |                                                                   |                                                                                                  |
+The basic item metadata that drive pack inference are:
 
-1. Back in the day, PDBs were Windows-only and fat files. Nowadays, portable PDBs 
-   (the new default) are lightweight and can even be embedded. Combined with [SourceLink](https://github.com/dotnet/sourcelink), including them in the package by default (either standalone or embeded) provides the best experience for your users, so it's the default.
-2. `PrivateAssets=all` in a `PackageReference` causes all the contributed files to the compilation to be packed together with the built output, unless `Pack=false` is also specified. Build-only dependencies that don't contribute assemblies to the output (i.e. analyzers or things like [GitInfo](https://github.com/kzu/GitInfo) or [ThisAssembly](https://github.com/kzu/ThisAssembly) won't cause any extra items).
-3. This is the most intuitive default: things that you typically copy to the output in order to "run" your project, is stuff that will typically also be needed at run-time when users reference your package. This can be MSBuild props/targets for a build tasks package, for example, or additional files used by an analyzer or a tool.
-4. `Reference` items are resolved by the `ResolveAssemblyReference` standard targets as `ReferencePath` items. Only those that have a `ResolvedFrom` metadata of `{TargetFrameworkDirectory}` are considered.
+1. **Pack**: *true*/*false*, determines whether inference applies to the item at all.
+2. **PackagePath**: final path within the package.
 
-Inference control properties and metadata:
+If the item does **not** provide a *PackagePath*, and *Pack* is not *false*, the inference targets wil try to determine the right value, based on the following additional metadata:
 
-| Property                              | Description                                                                                                                    |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `PackContent=true\|false`             | Turns on/off the default inference for `@(Content)`.  Items with `Pack=true` metadata are always included. Defaults to `true`. |
-| `PackNone=true\|false`                | Turns on/off the default inference for `@(None)`.  Items with `Pack=true` metadata are always included. Defaults to `false`.   |
-| `PackSymbols=true\|false`             | Turns on/off inclusion of symbols (if generated). Defaults to `true`.                                                          |
-| `PackFrameworkReferences=true\|false` | Turns on/off the default inference of `<Reference...` items                                                                    |
+a. **PackFolder**: typically one of the [built-in package folders](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs#L19), such as *build*, *lib*, etc.
+b. **FrameworkSpecific**: *true*/*false*, determines whether the project's target framework is used when building the final *PackagePath*.
 
-All of these [inference rules are laid out in a single .targets](src/NuGetizer.Tasks/NuGetizer.Inference.targets] file that's easy to inspect to learn more.
+When an item specifies *FrameworkSpecific=true*, the project's target framework is added to the final package path, such as `lib\netstandard2.0\My.dll`. Since the package folder itself typically determines whether it contains framework-specific files or not, the *FrameworkSpecific* value has sensible defaults so you don't have to specify it unless you wnat to override it. The [default values from NuGetizer.props](src/NuGetizer.Tasks/NuGetizer.props) are:
+
+| PackFolder       | FrameworkSpecific |
+|------------------|-------------------|
+| content (*)      | true              |
+| lib              | true              |
+| dependency (**)  | true              |
+| frameworkReference (**) | true       |
+| build            | false             |
+| all others (***) | false             |
+
+\* Since the plain *content* folder [is deprecated as of NuGet v3+](https://docs.nuget.org/ndocs/schema/nuspec#using-the-contentfiles-element-for-content-files), we use *content* to mean *contentFiles* throughout the docs, targets and implementation. They are interchangeable in NuGetizer and always mean the latter.
+
+\** *dependency* and *frameworkReference* are pseudo folders containing the package references and framework (`<Reference ...`) references.
+
+\** tool(s), native, runtime(s), ref, analyzer(s), source/src, any custom folder.
+
+The `PackFolder` property (at the project level) determines the *PackFolder* metadata value for the build outputs of the project (and its xml docs, pdb and other related files like satellite assemblies). It defaults to `lib`.
+
+For files that end up mapping to *content*, you can also specify *BuildAction*, *CopyToOutput* and *Flatten* item metadata, [as supported by NuGet v4+](https://docs.nuget.org/ndocs/schema/nuspec#using-the-contentfiles-element-for-content-files). In addition to those, NuGetizer also supports *CodeLanguage* and *TargetFramework* to [control the subfolders](https://docs.microsoft.com/en-us/nuget/reference/nuspec#package-folder-structure) too.
+
+Since it wouldn't be much fun having to annotate everything with either *PackFolder* or *PackagePath* (and also the additional *content* file metadata as needed), most common item types have sensible defaults too, defined in [NuGetizer.Inference.targets](src/NuGetizer.Tasks/NuGetizer.Inference.targets). 
+
+| ItemType        | Default Metadata  |
+|------------------|-------------------|
+| Content<br/>EmbeddedResource<br/>ApplicationDefinition<br/>Page<br/>Resource<br/>SplashScreen<br/>DesignData<br/>DesignDataWithDesignTimeCreatableTypes<br/>CodeAnalysisDictionary<br/>AndroidAsset<br/>AndroidResource<br/>BundleResource | PackFolder="content" <br/>BuildAction="[*ItemType*]" |
+| None             | PackFolder="" <br/>BuildAction="None"         |
+| Compile          | PackFolder="content" <br/>BuildAction="Compile"<br/>CodeLanguage="$(DefaultLanguageSourceExtension)"                |
+
+`None` is sort of special in that the package folder is root of the package by default.
+
+Whether items are packed by default or not is controlled by properties named after the item type (such as `PackEmbeddedResource`, `PackNone` and so on). Except for the ones below, they all default to *false* (or more precisely, empty, so, not *true*).
+
+| Property        | Default Value |
+|-----------------|---------------|
+| PackBuildOutput | true |
+| PackSymbols     | true if PackBuildOutput=true (*) |
+| PackFrameworkReferences | true if PackFolder=lib |
+| PackProjectReference | true |
+
+\* Back in the day, PDBs were Windows-only and fat files. Nowadays, portable PDBs 
+   (the new default) are lightweight and can even be embedded. Combined with [SourceLink](https://github.com/dotnet/sourcelink), including them in the package (either standalone or embeded) provides the best experience for your users, so it's the default.
+
+### CopyToOutputDirectory
+
+There is a common metadata item that's used quite frequently: *CopyToOutputDirectory*, which is typically set to *PreserveNewest* to change it from its default behavior (when empty or set to *Never*).
+
+> NOTE: if you're using *Always*, you're likely ruining your build performance for no reason.
+
+When copying items to the output directory, you're implicitly saying that those items are needed in order to run/execute the built output. For example, if you have build targets/props in a build-only project (i.e. the one that builds the tasks), then those files are needed alongside the built output when packaging.
+
+Given this common scenario, NuGetizer changes the default `PackFolder` metadata for packable items (i.e. those with explicit `Pack=true` metadata or defaulted to *true*, such as `Content` items) to match the `PackFolder` property defined for the project's built output, whenever `CopyToOutputDirectory` is not empty or *Never*.
+
+Like other default inference behaviors, you can always opt out of it by specifying an explicit *PackFolder` item metadata.
+
+In addition, the resulting `PackageFile` items for these items point to the location in the project's output folder, rather than the source location. This makes it easier to have custom behavior that might modify the item after copying to the output directory.
+
+### PackageReference
+
+Package references are turned into package dependencies by default (essentially converting `<PackageReference>` to `<PackageFile ... PackFolder="Dependency">`). If the package reference specifies `PrivateAssets="all"`, however, it's not added as a dependency. Instead, in that case, all the contributed files to the compilation are placed in the same `PackFolder` as the project's build output (if packable, depending on `PackBuildOutput` property).
+
+Build-only dependencies that don't contribute assemblies to the output (i.e. analyzers or things like [GitInfo](https://github.com/kzu/GitInfo) or [ThisAssembly](https://github.com/kzu/ThisAssembly) won't cause any extra items).
+
+This even works transitively, so if you use *PrivateAssets=all* on package reference *A*, which in turn has a package dependency on *B* and *B* in turn depends on *C*, all of *A*, *B* and *C* assets will be packed. 
+
+As usual, you can change this default behavior by using `Pack=false` metadata.
 
 ### Project References
 
-Unlike SDK Pack that [considers project references as package references by default](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#project-to-project-references), NuGetizer has an explicit contract between projects: `GetPackageContents`. This target is invoked when packing project references, and it returns whatever the referenced project exposes as package contents (including the inference rules above). If the project is *packable* (that is, it produces a package, denoted by the presence of a `PackageId` property), it will be packed as a dependency/package reference instead.
+Unlike SDK Pack that [considers project references as package references by default](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#project-to-project-references), NuGetizer has an explicit contract between projects: the `GetPackageContents` target. This target is invoked when packing project references, and it returns whatever the referenced project exposes as package contents (including the inference rules above). If the project is *packable* (that is, it produces a package, denoted by the presence of a `PackageId` property), it will be packed as a dependency/package reference instead.
 
-This means that by default, things Just Work: if you reference a library with no `PackageId`, it becomes part of whatever output your main project produces (analyzer, tools, plain lib). The moment you decide you want to make it a package on its own, you add the required metadata properties to that project, and automatically it becomes a dependency instead.
+This means that by default, things Just Work: if you reference a library with no `PackageId`, it becomes part of whatever output your main project produces (analyzer, tools, plain lib). The moment you decide you want to make it a package on its own, you add the required metadata properties to that project and it automatically becomes a dependency instead.
 
 This works flawlessly even when multi-targeting: if the main (packable) project multitargets `net472;netcoreapp3.1`, say, and it references a `netstandard2.0` (non-packable) library, the package contents will be:
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,7 +13,7 @@
   <Import Project="NuGetizer.Tasks\$(OutputPath)NuGetizer.targets" Condition="$(IsPackable) and '$(NuGetize)' == 'true'" />
 
   <PropertyGroup>
-    <PackageItemKindFile>$(IntermediateOutputPath)PackageItemKind.g$(DefaultLanguageSourceExtension)</PackageItemKindFile>
+    <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGetizer.Tasks/MetadataName.cs
+++ b/src/NuGetizer.Tasks/MetadataName.cs
@@ -4,7 +4,7 @@
     {
         public const string FileSource = "FullPath";
 
-        public const string Kind = nameof(Kind);
+        public const string PackFolder = nameof(PackFolder);
 
         public const string Version = nameof(Version);
 

--- a/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
@@ -14,15 +14,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
+  <PropertyGroup Label="SDK Pack Compat">
     <PackOnBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</PackOnBuild>
-    <BuildOutputKind Condition="'$(IsTool)' == 'true'">tool</BuildOutputKind>
-    <BuildOutputKind Condition="'$(BuildOutputTargetFolder)' != ''">$(BuildOutputTargetFolder)</BuildOutputKind>
+    <PackFolder Condition="'$(IsTool)' == 'true'">tool</PackFolder>
+    <PackFolder Condition="'$(BuildOutputTargetFolder)' != ''">$(BuildOutputTargetFolder)</PackFolder>
     <PackSymbols Condition="'$(PackSymbols)' == '' and '$(IncludeSymbols)' != ''">$(IncludeSymbols)</PackSymbols>
     <PackContent Condition="'$(PackContent)' == '' and '$(IncludeContentInPack)' != ''">$(IncludeContentInPack)</PackContent>
     <PackCompile Condition="'$(PackCompile)' == '' and '$(IncludeSource)' != ''">$(IncludeSource)</PackCompile>
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IncludeBuildOutput)' != ''">$(IncludeBuildOutput)</PackBuildOutput>
     <Description Condition="'$(Description)' == '' and '$(PackageDescription)' != ''">$(PackageDescription)</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Legacy NuGetizer Compat">
+    <PackFolder Condition="'$(PackFolder)' == '' and '$(BuildOutputKind)' != ''">$(BuildOutputKind)</PackFolder>
+    <PackFolder Condition="'$(PackFolder)' == '' and '$(PrimaryOutputKind)' != ''">$(PrimaryOutputKind)</PackFolder>
+    
+    <PackContent Condition="'$(PackContent)' == '' and '$(IncludeContentInPackage)' != ''">$(IncludeContentInPackage)</PackContent>
+    <PackNone Condition="'$(PackNone)' == '' and '$(IncludeNoneInPackage)' != ''">$(IncludeNoneInPackage)</PackNone>
+    <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IncludeOutputsInPackage)' != ''">$(IncludeOutputsInPackage)</PackBuildOutput>
+    <PackSymbols Condition="'$(PackSymbols)' == '' and '$(IncludeSymbolsInPackage)' != ''">$(IncludeSymbolsInPackage)</PackSymbols>
+    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IncludeFrameworkReferencesInPackage)' != ''">$(IncludeFrameworkReferencesInPackage)</PackFrameworkReferences>
   </PropertyGroup>
 
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -13,25 +13,19 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGetizer.Tasks.InferImplicitPackageReference" AssemblyFile="NuGetizer.Tasks.dll" />
 
   <PropertyGroup>
-    <!-- The Kind of primary output (build, symbols and doc) set if PackBuildOutput = true -->
-    <BuildOutputKind Condition="'$(BuildOutputKind)' == ''">Lib</BuildOutputKind>
+    <!-- The PackFolder of primary output (build, symbols, doc and satellite assemblies) set if PackBuildOutput = true -->
+    <PackFolder Condition="'$(PackFolder)' == ''">lib</PackFolder>
 
-    <!-- Whether to include @(Compile) items in the package -->
-    <PackCompile Condition="'$(PackCompile)' == ''">false</PackCompile>
     <!-- Whether to include @(Content) items with CopyToOutputDirectory != '' in the package -->
     <PackContent Condition="'$(PackContent)' == ''">true</PackContent>
-    <!-- Whether to include @(None) items with CopyToOutputDirectory != '' in the package -->
-    <PackNone Condition="'$(PackNone)' == ''">false</PackNone>
-    <!-- Whether to include @(None) items with CopyToOutputDirectory != '' in the package -->
-    <PackEmbeddedResource Condition="'$(PackEmbeddedResource)' == ''">false</PackEmbeddedResource>   
     <!-- Whether to include @(BuiltProjectOutputGroupOutput), @(DocumentationProjectOutputGroupOutput) and @(SatelliteDllsProjectOutputGroupOutput) items in the package -->
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IsPackagingProject)' != 'true'">true</PackBuildOutput>
     <!-- Whether to include @(DebugSymbolsProjectOutputGroupOutput) items in the package -->
     <PackSymbols Condition="'$(PackSymbols)' == '' and '$(PackBuildOutput)' == 'true'">true</PackSymbols>
-    <!-- Whether to include framework references (%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}') in the package -->
 
+    <!-- Whether to include framework references (%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}') in the package -->
     <!-- Only default to true if the project isn't a nuget packaging project itself and its primary output is lib. -->
-    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IsPackagingProject)' != 'true' and '$(BuildOutputKind)' == 'Lib'">true</PackFrameworkReferences>
+    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IsPackagingProject)' != 'true' and '$(PackFolder)' == 'lib'">true</PackFrameworkReferences>
 
     <_OutputFullPath Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</_OutputFullPath>
     <_OutputFullPath Condition="'$(_OutputFullPath)' == ''">$(MSBuildProjectDirectory.TrimEnd('\'))\$(OutputPath)</_OutputFullPath>
@@ -41,81 +35,81 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Compile>
       <!-- For Compile, the CodeLanguage should default to the project's default source extension -->
       <CodeLanguage>$(DefaultLanguageSourceExtension.TrimStart('.'))</CodeLanguage>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackCompile)' == 'true'">true</Pack>
       <BuildAction>Compile</BuildAction>
     </Compile>
     <Content>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackContent)' == true">true</Pack>
       <BuildAction>Content</BuildAction>
     </Content>
     <EmbeddedResource>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackEmbeddedResource)' == true">true</Pack>
       <BuildAction>EmbeddedResource</BuildAction>
     </EmbeddedResource>
     <None>
-      <DefaultKind>none</DefaultKind>
+      <DefaultPackFolder>none</DefaultPackFolder>
       <Pack Condition="'$(PackNone)' == true">true</Pack>
       <BuildAction>None</BuildAction>
     </None>
     <ApplicationDefinition>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackApplicationDefinition)' == true">true</Pack>
       <BuildAction>ApplicationDefinition</BuildAction>
     </ApplicationDefinition>
     <Page>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackPage)' == true">true</Pack>
       <BuildAction>Page</BuildAction>
     </Page>
     <Resource>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackResource)' == true">true</Pack>
       <BuildAction>Resource</BuildAction>
     </Resource>
     <SplashScreen>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackSplashScreen)' == true">true</Pack>
       <BuildAction>SplashScreen</BuildAction>
     </SplashScreen>
     <DesignData>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackDesignData)' == true">true</Pack>
       <BuildAction>DesignData</BuildAction>
     </DesignData>
     <DesignDataWithDesignTimeCreatableTypes>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackDesignDataWithDesignTimeCreatableTypes)' == true">true</Pack>
       <BuildAction>DesignDataWithDesignTimeCreatableTypes</BuildAction>
     </DesignDataWithDesignTimeCreatableTypes>
     <CodeAnalysisDictionary>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackCodeAnalysisDictionary)' == true">true</Pack>
       <BuildAction>CodeAnalysisDictionary</BuildAction>
     </CodeAnalysisDictionary>
     <AndroidAsset>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackAndroidAsset)' == true">true</Pack>
       <BuildAction>AndroidAsset</BuildAction>
     </AndroidAsset>
     <AndroidResource>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackAndroidResource)' == true">true</Pack>
       <BuildAction>AndroidResource</BuildAction>
     </AndroidResource>    
     <BundleResource>
-      <DefaultKind>content</DefaultKind>
+      <DefaultPackFolder>content</DefaultPackFolder>
       <Pack Condition="'$(PackBundleResource)' == true">true</Pack>
       <BuildAction>BundleResource</BuildAction>
     </BundleResource>
     
     <InferenceCandidate>
-      <DefaultKind />
+      <DefaultPackFolder />
       <Pack />
       <PackagePath />
-      <Kind />
+      <PackFolder />
       <ShouldPack />
     </InferenceCandidate>
   </ItemDefinitionGroup>
@@ -151,14 +145,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_SetBuildOutputFrameworkSpecific" Condition="'$(BuildOutputFrameworkSpecific)' == ''" Returns="$(BuildOutputFrameworkSpecific)">
     <!-- Determine whether primary output is framework specific  -->
     <ItemGroup>
-      <_BuildOutputKindFrameworkSpecific Include="@(PackageItemKind->'%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(BuildOutputKind)'" />
+      <_BuildOutputFrameworkSpecific Include="@(PackFolderKind -> '%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(PackFolder)'" />
     </ItemGroup>
     <PropertyGroup>
-      <BuildOutputFrameworkSpecific>@(_BuildOutputKindFrameworkSpecific)</BuildOutputFrameworkSpecific>
+      <BuildOutputFrameworkSpecific>@(_BuildOutputFrameworkSpecific)</BuildOutputFrameworkSpecific>
     </PropertyGroup>
   </Target>
   
-  <Target Name="_SetDefaultPackageReferencePack" Condition="'$(BuildOutputKind)' == 'build'"
+  <Target Name="_SetDefaultPackageReferencePack" Condition="'$(PackFolder)' == 'build'"
           BeforeTargets="InferPrimaryOutputDependencies;InferPackageContents">
     <ItemGroup>
       <PackageReference Update="@(PackageReference)"
@@ -177,7 +171,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <InferenceCandidate Include="@(%(PackInference.Identity))" />
       <InferenceCandidate>
-        <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(Kind)' != '') and '%(Pack)' != 'false'">true</ShouldPack>
+        <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(PackFolder)' != '') and '%(Pack)' != 'false'">true</ShouldPack>
       </InferenceCandidate>
     </ItemGroup>
 
@@ -187,13 +181,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </AssignTargetPath>
 
     <ItemGroup Label="PackInference">
-      <_InferenceCandidateWithTargetPath Condition="'%(Kind)' == ''">
+      <_InferenceCandidateWithTargetPath Condition="'%(PackFolder)' == ''">
         <!-- Items that are copied to the output directory adopt the kind of the build output -->
-        <Kind Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != '' or 
-                         '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != 'Never'">$(BuildOutputKind)</Kind>
+        <PackFolder Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != '' or 
+                               '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != 'Never'">$(PackFolder)</PackFolder>
         <!-- Otherwise they cake on whichever is the default for their item type, as defined by their PackInference item -->
-        <Kind Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == '' or 
-                         '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == 'Never'">%(_InferenceCandidateWithTargetPath.DefaultKind)</Kind>        
+        <PackFolder Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == '' or 
+                               '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == 'Never'">%(_InferenceCandidateWithTargetPath.DefaultPackFolder)</PackFolder>        
       </_InferenceCandidateWithTargetPath>
       
         <!-- Items that are copied to the output directory are included from the target path -->
@@ -217,13 +211,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      @(BuiltProjectOutputGroupKeyOutput -> '%(FinalOutputPath)');
                                      @(DocumentationProjectOutputGroupOutput -> '%(FinalOutputPath)');
                                      @(_SatelliteDllsProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <Kind>$(BuildOutputKind)</Kind>
+        <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
       </_InferredProjectOutput>
 
       <_InferredProjectOutput Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                             Condition="'$(PackSymbols)' != 'false'">
-        <Kind>$(BuildOutputKind)</Kind>
+        <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
       </_InferredProjectOutput>
 
@@ -236,7 +230,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        '%(PackageReference.Identity)' != 'NETStandard.Library' and 
                                        '%(PackageReference.PrivateAssets)' != 'all' and
                                        '%(PackageReference.Pack)' != 'false'">
-        <Kind>Dependency</Kind>
+        <PackFolder>Dependency</PackFolder>
       </_InferredPackageFile>
 
       <!-- We can't use %(FrameworkFile)==true because it's not defined for raw file references and 
@@ -246,7 +240,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             Condition="'$(PackFrameworkReferences)' == 'true' and 
                                        '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}' and 
                                        '%(ReferencePath.Pack)' != 'false'">
-        <Kind>FrameworkReference</Kind>
+        <PackFolder>FrameworkReference</PackFolder>
       </_InferredPackageFile>
     </ItemGroup>
 
@@ -308,7 +302,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(_ShouldPack)' != 'false' and '$(_PrivateAssets)' == 'all'">
       <_InferredPackageFile Include="@(_PrimaryOutputRelatedFile)" Condition="'%(_PrimaryOutputRelatedFile.FrameworkFile)' != 'true'">
-        <Kind>$(BuildOutputKind)</Kind>
+        <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
       </_InferredPackageFile>
     </ItemGroup>
@@ -319,7 +313,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 				 'Mono.Options\*\lib\*', meaning the file is a lib. -->
       <_InferredPackageFile Include="@(_PrimaryOutputRelatedFile)" 
                             Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(_PrimaryOutputRelatedFile.FullPath)', '$(_ShouldIncludeAssetsRegex)', 'RegexOptions.IgnoreCase')) == 'true'">
-        <Kind>$(BuildOutputKind)</Kind>
+        <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
       </_InferredPackageFile>
     </ItemGroup>

--- a/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
@@ -60,7 +60,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   
     <!-- _AddPackageManifest adds per-TFM, so deduplicate and remove the TFM -->
     <ItemGroup Condition="'$(IsPackable)' == 'true'">
-      <_PackageMetadataContent Include="@(_PackageContent -> WithMetadataValue('Kind', 'Metadata'))" />
+      <_PackageMetadataContent Include="@(_PackageContent -> WithMetadataValue('PackFolder', 'Metadata'))" />
       <_PackageContent Remove="@(_PackageMetadataContent)" />
       <_PackageContent Include="@(_PackageMetadataContent -> Distinct())">
         <AdditionalProperties />

--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <!-- Whether to infer package contents -->
-    <EnablePackInference Condition="'$(EnablePackInference)' == ''" />
+    <EnablePackInference Condition="'$(EnablePackInference)' == ''">true</EnablePackInference>
 
     <!-- Whether include referenced projects' contents in the package. -->
     <PackProjectReference Condition="'$(PackProjectReference)' == ''">true</PackProjectReference>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
@@ -45,43 +45,43 @@
 
   <PropertyGroup>
     <CoreCompileDependsOn>
-      PackageItemKind;
+      IncludePackFolderKind;
       $(CoreCompileDependsOn);
     </CoreCompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="PackageItemKind" BeforeTargets="BuildOnlySettings" DependsOnTargets="GeneratePackageItemKind">
+  <Target Name="IncludePackFolderKind" BeforeTargets="BuildOnlySettings" DependsOnTargets="GeneratePackFolderKind">
     <ItemGroup>
-      <Compile Include="$(PackageItemKindFile)" />
+      <Compile Include="$(PackFolderKindFile)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GeneratePackageItemKind" Inputs="$(MSBuildThisFileFullPath);NuGetizer.props" Outputs="$(PackageItemKindFile)">
+  <Target Name="GeneratePackFolderKind" Inputs="$(MSBuildThisFileFullPath);NuGetizer.props" Outputs="$(PackFolderKindFile)">
     <MakeDir Directories="$(IntermediateOutputPath)" Condition=" !Exists('$(IntermediateOutputPath)') " />
-    <MSBuild Projects="NuGetizer.props" Targets="_GetPackageItemKinds">
-      <Output ItemName="_PackageItemKind" TaskParameter="TargetOutputs" />
+    <MSBuild Projects="NuGetizer.props" Targets="_GetPackFolders">
+      <Output ItemName="_PackFolderKind" TaskParameter="TargetOutputs" />
     </MSBuild>
 
     <WriteLinesToFile Lines='
 namespace $(RootNamespace)
 {
-	/// &lt;summary&gt;Available Kind metadata for PackageFile and _PackageContent items&lt;/summary&gt;
-	public static partial class PackageItemKind
+	/// &lt;summary&gt;Known PackFolder metadata values for PackageFile and _PackageContent items&lt;/summary&gt;
+	public static partial class PackFolderKind
 	{
-' Overwrite='true' File='$(PackageItemKindFile)' />
+' Overwrite='true' File='$(PackFolderKindFile)' />
 
-    <WriteLinesToFile Lines='				  
-		/// &lt;summary&gt;Kind: %(_PackageItemKind.Identity)&lt;/summary&gt;
-		public const string %(_PackageItemKind.Identity) = nameof(%(_PackageItemKind.Identity))%3B
-' Overwrite='false' File='$(PackageItemKindFile)' />
+    <WriteLinesToFile Lines='
+		/// &lt;summary&gt;PackageFolder: $([MSBuild]::ValueOrDefault(%(PackageFolder), %(Identity)))&lt;/summary&gt;
+		public const string %(_PackFolderKind.Identity) = "$([MSBuild]::ValueOrDefault(%(PackageFolder), %(Identity)))"%3B
+' Overwrite='false' File='$(PackFolderKindFile)' />
 
     <WriteLinesToFile Lines='
 	}
 }
-' Overwrite='false' File='$(PackageItemKindFile)' />
+' Overwrite='false' File='$(PackFolderKindFile)' />
 
     <ItemGroup>
-      <FileWrites Include="$(PackageItemKindFile)" />
+      <FileWrites Include="$(PackFolderKindFile)" />
     </ItemGroup>
   </Target>
 

--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -32,8 +32,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemDefinitionGroup>
     <PackageFile>
-      <!-- See @(PackageItemKind) below -->
-      <Kind>None</Kind>
+      <!-- See @(PackFolderKind) below -->
+      <PackFolder>None</PackFolder>
       <!-- By default, we consider all PackageFile items to be explicitly added by the user
 				 the automatic discovery will annotate those with Implicit instead. 
 				 This allows the duplicate item detection to either warn (Implicit) or error (Explicit). -->
@@ -46,18 +46,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- When set to All, denotes a development dependency -->
       <PrivateAssets />
     </PackageReference>
-    <PackageItemKind>
+    <PackFolderKind>
       <!-- PackageFolder should map to a supported folder as defined in PackagingConstants.Folders -->
       <!-- If empty, causes the file to end up in %(RelativeDir) -->
       <PackageFolder />
       <!-- FrameworkSpecific is whether the PackagePath will include the project's TF or not -->
       <FrameworkSpecific>false</FrameworkSpecific>
-    </PackageItemKind>
+    </PackFolderKind>
   </ItemDefinitionGroup>
 
-  <!-- Default mapping between %(PackageFile.Kind) metadata and package folders inside .nupkg -->
+  <!-- Default mapping between %(PackageFile.PackageFolder) metadata and package folders inside .nupkg -->
   <ItemGroup>
-    <PackageItemKind Include="Content;ContentFiles">
+    <PackFolderKind Include="Content;ContentFiles">
       <!-- 
 					Plain "content" is deprecated as of NuGet v3+
 					See https://docs.nuget.org/ndocs/schema/nuspec#using-the-contentfiles-element-for-content-files
@@ -69,61 +69,61 @@ Copyright (c) .NET Foundation. All rights reserved.
 			-->
       <PackageFolder>contentFiles</PackageFolder>
       <FrameworkSpecific>true</FrameworkSpecific>
-    </PackageItemKind>
-    <PackageItemKind Include="None" />
+    </PackFolderKind>
+    <PackFolderKind Include="None" />
     <!-- 
 				NOTE: these aren't strictly necessary since we turn any custom 
-				Kind metadata into a PackageFolder by making the first char lowercase
+				PackageFolder metadata into a PackageFolder by making the first char lowercase
 				We also add singular form of the built-in plural form folders where it makes sense.
 		-->
-    <PackageItemKind Include="Lib">
+    <PackFolderKind Include="Lib">
       <PackageFolder>lib</PackageFolder>
       <FrameworkSpecific>true</FrameworkSpecific>
-    </PackageItemKind>
-    <PackageItemKind Include="Build">
+    </PackFolderKind>
+    <PackFolderKind Include="Build">
       <PackageFolder>build</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Tool;Tools">
+    </PackFolderKind>
+    <PackFolderKind Include="Tool;Tools">
       <PackageFolder>tools</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Native">
+    </PackFolderKind>
+    <PackFolderKind Include="Native">
       <PackageFolder>native</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Runtime;Runtimes">
+    </PackFolderKind>
+    <PackFolderKind Include="Runtime;Runtimes">
       <PackageFolder>runtimes</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Ref">
+    </PackFolderKind>
+    <PackFolderKind Include="Ref">
       <PackageFolder>ref</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Analyzer;Analyzers">
+    </PackFolderKind>
+    <PackFolderKind Include="Analyzer;Analyzers">
       <PackageFolder>analyzers</PackageFolder>
-    </PackageItemKind>
-    <PackageItemKind Include="Source">
+    </PackFolderKind>
+    <PackFolderKind Include="Source">
       <PackageFolder>source</PackageFolder>
-    </PackageItemKind>
+    </PackFolderKind>
 
-    <!-- For unknown Kind we apply the heuristics of turning the metadata value into pascalCase 
+    <!-- For unknown PackageFolder we apply the heuristics of turning the metadata value into pascalCase 
              and using that as the package folder (i.e. 'Workbooks' -> 'workbooks') -->
 
     <!-- Finally, specially treated items that we include here for completeness and documentation -->
 
     <!-- PackageReference items end up as Dependency -->
     <!-- Project references that build packages also end up as package dependencies -->
-    <PackageItemKind Include="Dependency">
+    <PackFolderKind Include="Dependency">
       <!-- See https://github.com/NuGet/Home/wiki/PackageReference-Specification for the available metadata -->
       <FrameworkSpecific>true</FrameworkSpecific>
-    </PackageItemKind>
+    </PackFolderKind>
 
     <!-- The package metadata item if the project generates a package -->
-    <PackageItemKind Include="Metadata" />
+    <PackFolderKind Include="Metadata" />
 
     <!-- Platform targets could turn @(ReferencePath) with ResolvedFrom={TargetFrameworkDirectory} to FrameworkReference, for example -->
-    <PackageItemKind Include="FrameworkReference">
+    <PackFolderKind Include="FrameworkReference">
       <FrameworkSpecific>true</FrameworkSpecific>
-    </PackageItemKind>
+    </PackFolderKind>
   </ItemGroup>
 
-  <Target Name="_GetPackageItemKinds" Returns="@(PackageItemKind)" />
+  <Target Name="_GetPackFolders" Returns="@(PackFolderKind)" />
   <!-- Redefined in Common targets. See PackageOutputGroup target -->
   <Target Name="AllProjectOutputGroups" />
 

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -34,7 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   item containing the manifest information will also be returned, as 
 	
     Identity=$(PackageId)
-      %(Kind)=Metadata
+      %(PackFolder)=metadata
       ... all manifest values as metadata items ...
 	
   All items returned from this target contain a %(PackageId) metadata 
@@ -72,7 +72,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- We batch depending on the IsPackaging metadata, which is only specified for referenced content 
 			 if the current project is building a package, to force retargeting of the referenced content. -->
-    <AssignPackagePath Files="@(PackageFile)" Kinds="@(PackageItemKind)" IsPackaging="%(PackageFile.IsPackaging)">
+    <AssignPackagePath Files="@(PackageFile)" KnownFolders="@(PackFolderKind)" IsPackaging="%(PackageFile.IsPackaging)">
       <Output TaskParameter="AssignedFiles" ItemName="_PackageContent" />
     </AssignPackagePath>
   </Target>
@@ -81,7 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If packaging the project, provide the metadata as a non-file item -->
     <ItemGroup>
       <PackageFile Include="@(PackageMetadata)">
-        <Kind>Metadata</Kind>
+        <PackFolder>metadata</PackFolder>
         <PackageId>$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
         <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
@@ -115,11 +115,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_ReferencedPackageDependency Include="@(_ReferencedPackageContent)"
-                                    Condition="'%(_ReferencedPackageContent.PackageId)' != '$(PackageId)' and '%(_ReferencedPackageContent.Kind)' == 'Metadata'">
+                                    Condition="'%(_ReferencedPackageContent.PackageId)' != '$(PackageId)' and '%(_ReferencedPackageContent.PackFolder)' == 'metadata'">
         <!-- For consistency, annotate like the rest -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
-        <Kind>Dependency</Kind>
+        <PackFolder>Dependency</PackFolder>
       </_ReferencedPackageDependency>
       <!-- Remove the referenced package actual contents if it provides a manifest, since it will be a dependency in that case. -->
       <_PackageContentFromDependency Include="@(_ReferencedPackageContent)"

--- a/src/NuGetizer.Tasks/Resources.resx
+++ b/src/NuGetizer.Tasks/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ErrorCode_NG0010" xml:space="preserve">
-    <value>Package file '{0}' must have either 'Kind' or 'PackagePath' metadata.</value>
+    <value>Package file '{0}' must have either 'PackFolder' or 'PackagePath' metadata.</value>
   </data>
   <data name="ErrorCode_NG0011" xml:space="preserve">
     <value>Project references to include in package must be nugetized.</value>

--- a/src/NuGetizer.Tests/AssignPackagePathTests.cs
+++ b/src/NuGetizer.Tests/AssignPackagePathTests.cs
@@ -18,7 +18,7 @@ namespace NuGetizer
 
 		static ITaskItem[] Kinds
             => kinds ??= new Project(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NuGetizer.props"), null, null, new ProjectCollection())
-                .GetItems("PackageItemKind")
+                .GetItems("PackFolderKind")
                 .Select(item => new TaskItem(item.EvaluatedInclude, item.Metadata.ToDictionary(meta => meta.Name, meta => meta.UnevaluatedValue)))
                 .ToArray();
 
@@ -37,7 +37,7 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
@@ -58,7 +58,7 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
@@ -83,7 +83,7 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
@@ -109,20 +109,20 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("a.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					}),
 					new TaskItem("a.pdb", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Symbols" }
+						{ "PackFolder", "symbols" }
 					})
 				}
 			};
@@ -138,13 +138,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -160,13 +160,13 @@ namespace NuGetizer
 			{
 				IsPackaging = "true",
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -181,13 +181,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -205,13 +205,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -229,13 +229,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -255,13 +255,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
-						{ "Kind", "ContentFiles" },
+						{ "PackFolder", "contentFiles" },
 						{ "TargetFramework", "any" },
 						{ "TargetFrameworkMoniker", "MonoAndroid,Version=v2.5" },
 					})
@@ -282,14 +282,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem(@"..\..\readme.txt", new Metadata
 					{
 						{ "Link", @"docs\readme.txt" },
 						{ "PackageId", "A" },
-						{ "Kind", "Content" },
+						{ "PackFolder", "content" },
 						{ "TargetFramework", "any" },
 					})
 				}
@@ -310,14 +310,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem(@"..\..\readme.txt", new Metadata
 					{
 						{ "Link", @"docs\readme.txt" },
 						{ "PackageId", "A" },
-						{ "Kind", "None" },
+						{ "PackFolder", "none" },
 						{ "TargetFramework", "any" },
 					})
 				}
@@ -339,13 +339,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("readme.txt", new Metadata
 					{
 						{ "PackageId", "A" },
-						{ "Kind", "Content" },
+						{ "PackFolder", "content" },
 						{ "FrameworkSpecific", "false" },
 						{ "TargetFrameworkMoniker", "MonoAndroid,Version=v2.5" },
 					})
@@ -375,14 +375,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", targetFrameworkMoniker },
-						{ "Kind", "Lib" }
+						{ "PackFolder", "lib" }
 					})
 				}
 			};
@@ -411,14 +411,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", packageFileKind }
+						{ "PackFolder", packageFileKind }
 					})
 				}
 			};
@@ -437,7 +437,7 @@ namespace NuGetizer
 		public static IEnumerable<object[]> GetUnmappedKnownKinds => Kinds
 			.Where(kind => string.IsNullOrEmpty(kind.GetMetadata(MetadataName.PackageFolder)) && 
 				kind.GetMetadata(MetadataName.PackageFolder) != "contentFiles" && 
-				kind.ItemSpec != PackageItemKind.None)
+				kind.ItemSpec != PackFolderKind.None)
 			.Select(kind => new object[] { kind.ItemSpec });
 
 		[MemberData(nameof(GetUnmappedKnownKinds))]
@@ -447,14 +447,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("Foo", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", packageFileKind }
+						{ "PackFolder", packageFileKind }
 					})
 				}
 			};
@@ -472,14 +472,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("readme.txt", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "None" },
+						{ "PackFolder", "none" },
 						{ "PackagePath", "docs\\readme.txt" }
 					})
 				}
@@ -503,14 +503,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("Sample.cs", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", tfm },
-						{ "Kind", "Content" },
+						{ "PackFolder", "content" },
 						{ "CodeLanguage", lang }
 					})
 				}
@@ -528,7 +528,7 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem(@"contentFiles\cs\monodroid\content.cs", new Metadata
@@ -536,7 +536,7 @@ namespace NuGetizer
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
 						{ "TargetPath", @"contentFiles\cs\monodroid\content.cs" },
-						{ "Kind", "Content" },
+						{ "PackFolder", "content" },
 					})
 				}
 			};
@@ -551,14 +551,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("Sample.cs", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Content" },
+						{ "PackFolder", "content" },
 						{ MetadataName.ContentFile.CodeLanguage, "cs" },
 						{ MetadataName.ContentFile.BuildAction, "EmbeddedResource" },
 						{ MetadataName.ContentFile.CopyToOutput, "true" },
@@ -583,14 +583,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem(@"content\docs\readme.txt", new Metadata
 					{						
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "None" },
+						{ "PackFolder", "none" },
 					})
 				}
 			};
@@ -609,14 +609,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "None" },
+						{ "PackFolder", "none" },
 						{ "TargetPath", "workbook\\library.dll"}
 					})
 				}
@@ -636,14 +636,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "None" }
+						{ "PackFolder", "none" }
 					})
 				}
 			};
@@ -661,14 +661,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("library.dll", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", packageFileKind }
+						{ "PackFolder", packageFileKind }
 					})
 				}
 			};
@@ -687,13 +687,13 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Metadata
 					{
 						{ "PackageId", "A" },
-						{ "Kind", "Tool" },
+						{ "PackFolder", "tool" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}
 					})
 				}
@@ -712,14 +712,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("sdk\\bin\\tool.exe", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Tool" },
+						{ "PackFolder", "tool" },
 						{ "FrameworkSpecific", "true" },
 						{ "TargetPath", "sdk\\bin\\tool.exe"}
 					})
@@ -739,14 +739,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("console.exe", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Lib" },
+						{ "PackFolder", "lib" },
 						{ "FrameworkSpecific", "false" },
 					})
 				}
@@ -765,14 +765,14 @@ namespace NuGetizer
 			var task = new AssignPackagePath
 			{
 				BuildEngine = engine,
-				Kinds = Kinds,
+				KnownFolders = Kinds,
 				Files = new ITaskItem[]
 				{
 					new TaskItem("tools\\foo.exe", new Metadata
 					{
 						{ "PackageId", "A" },
 						{ "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
-						{ "Kind", "Tools" },
+						{ "PackFolder", "tools" },
 					})
 				}
 			};

--- a/src/NuGetizer.Tests/CreatePackageTests.cs
+++ b/src/NuGetizer.Tests/CreatePackageTests.cs
@@ -76,7 +76,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -115,7 +115,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -150,7 +150,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" }
@@ -177,7 +177,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" },
@@ -203,7 +203,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" },
@@ -229,7 +229,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" }
@@ -253,7 +253,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" }
@@ -277,7 +277,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" },
 					{ MetadataName.FrameworkSpecific, "false" },
@@ -285,7 +285,7 @@ namespace NuGetizer
 				new TaskItem("Microsoft.Build", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "15.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -320,14 +320,14 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "any" },
 				}),
 				new TaskItem("Microsoft.Build", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "15.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -360,34 +360,34 @@ namespace NuGetizer
 				new TaskItem(Path.GetTempFileName(), new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackFolder, PackFolderKind.None },
 					{ MetadataName.PackagePath, "readme.txt" }
 				}),
 				new TaskItem("_._", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "*" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
 				new TaskItem("_._", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "*" },
 					{ MetadataName.TargetFramework, "win" }
 				}),
 				new TaskItem("_._", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "*" },
 					{ MetadataName.TargetFramework, "wpa" }
 				}),
 				new TaskItem("_._", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "*" },
 					{ MetadataName.TargetFramework, "MonoAndroid10" }
 				}),
@@ -412,21 +412,21 @@ namespace NuGetizer
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.PackagePath, "lib\\net35\\library.dll" },
-					{ MetadataName.Kind, PackageItemKind.Lib },
+					{ MetadataName.PackFolder, PackFolderKind.Lib },
 					{ MetadataName.TargetFramework, "net35" }
 				}),
 				new TaskItem(Path.GetTempFileName(), new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.PackagePath, "lib\\net40\\library.dll" },
-					{ MetadataName.Kind, PackageItemKind.Lib },
+					{ MetadataName.PackFolder, PackFolderKind.Lib },
 					{ MetadataName.TargetFramework, "net40" }
 				}),
 				new TaskItem(Path.GetTempFileName(), new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.PackagePath, "lib\\net45\\library.dll" },
-					{ MetadataName.Kind, PackageItemKind.Lib },
+					{ MetadataName.PackFolder, PackFolderKind.Lib },
 					{ MetadataName.TargetFramework, "net45" }
 				})
 			};
@@ -453,14 +453,14 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackFolder, PackFolderKind.None },
 					{ MetadataName.PackagePath, "readme.txt" }
 				}),
 				new TaskItem("Helpers", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
 					{ MetadataName.Version, "1.0.0" },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.PrivateAssets, "all" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" }
@@ -480,7 +480,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					// NOTE: AssignPackagePath takes care of converting TFM > short name
 					{ MetadataName.TargetFramework, "net45" }
@@ -508,7 +508,7 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.None },
+					{ MetadataName.PackFolder, PackFolderKind.None },
 					{ MetadataName.PackagePath, "readme.txt" }
 				}),
 			};
@@ -528,7 +528,7 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackFolder, PackFolderKind.ContentFiles },
 					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
 					{ MetadataName.PackagePath, @"contentFiles\any\any\readme.txt" }
 				}),
@@ -549,7 +549,7 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackFolder, PackFolderKind.ContentFiles },
 					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
 					{ MetadataName.ContentFile.BuildAction, "EmbeddedResource" },
 					{ MetadataName.PackagePath, @"contentFiles\any\any\readme.txt" }
@@ -572,7 +572,7 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackFolder, PackFolderKind.ContentFiles },
 					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
 					{ MetadataName.ContentFile.CopyToOutput, "true" },
 					{ MetadataName.PackagePath, @"contentFiles\any\any\readme.txt" }
@@ -604,7 +604,7 @@ namespace NuGetizer
 				new TaskItem(content, new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.ContentFiles },
+					{ MetadataName.PackFolder, PackFolderKind.ContentFiles },
 					{ MetadataName.PackageFolder, PackagingConstants.Folders.ContentFiles },
 					{ MetadataName.ContentFile.Flatten, "true" },
 					{ MetadataName.PackagePath, @"contentFiles\any\any\readme.txt" }
@@ -641,13 +641,13 @@ namespace NuGetizer
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
 				}),
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
 				}),
 			};
@@ -673,25 +673,25 @@ namespace NuGetizer
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
 				}),
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET45 }
 				}),
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
 				}),
 				new TaskItem("System.Xml", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.FrameworkReference },
+					{ MetadataName.PackFolder, PackFolderKind.FrameworkReference },
 					{ MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
 				}),
 			};
@@ -728,7 +728,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -758,7 +758,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -788,7 +788,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),
@@ -823,7 +823,7 @@ namespace NuGetizer
 				new TaskItem("Newtonsoft.Json", new Metadata
 				{
 					{ MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
-					{ MetadataName.Kind, PackageItemKind.Dependency },
+					{ MetadataName.PackFolder, PackFolderKind.Dependency },
 					{ MetadataName.Version, "8.0.0" },
 					{ MetadataName.TargetFramework, "net45" }
 				}),

--- a/src/NuGetizer.Tests/Scenarios/Scenario.targets
+++ b/src/NuGetizer.Tests/Scenarios/Scenario.targets
@@ -11,7 +11,7 @@
   <Target Name="Report" DependsOnTargets="GetPackageContents">
     <Message Importance="high" 
              Text="%(_PackageContent.RelativeDir)%(_PackageContent.Filename)%(_PackageContent.Extension)
-	Kind=%(_PackageContent.Kind)
+	Kind=%(_PackageContent.PackFolder)
 	PackagePath=%(_PackageContent.PackagePath)
 	TargetPath=%(_PackageContent.TargetPath)"/>
   </Target>

--- a/src/NuGetizer.Tests/Scenarios/given_a_library_with_content/library_with_content.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_a_library_with_content/library_with_content.csproj
@@ -25,24 +25,24 @@
     <Content Include="contentFiles\cs\monoandroid\content.cs" Condition="'$(IncludeContentWithReservedRelativeDir)' == 'true'" />
     <Content Include="cs\any\any-content.cs" />
     <None Include="none.txt" />
-    <None Include="none-with-kind.txt" Kind="build" />
+    <None Include="none-with-kind.txt" PackFolder="build" />
     <None Include="none-with-include-true.txt" Pack="true" />
 		<None Include="none-with-include-false.txt" Pack="false" />
     <None Include="none-copy.txt" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="none-copy-with-kind.txt" Kind="build" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="none-copy-with-kind.txt" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
     <None Include="none-copy-with-include-true.txt" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <None Include="none-copy-with-include-false.txt" Pack="false" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="relative\none-copy-with-kind.txt" Kind="build" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="relative\none-copy-with-kind.txt" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="relative\none-copy.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="content.txt" />
-    <Content Include="content-with-kind.txt" Kind="build" />
+    <Content Include="content-with-kind.txt" PackFolder="build" />
     <Content Include="content-with-include-true.txt" Pack="true" />
     <Content Include="content-with-include-false.txt" Pack="false" />
     <Content Include="content-copy.txt" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="content-copy-with-kind.txt" Kind="build" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="content-copy-with-kind.txt" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="content-copy-with-include-true.txt" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="content-copy-with-include-false.txt" Pack="false" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="relative\content-copy-with-kind.txt" Kind="build" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="relative\content-copy-with-kind.txt" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="relative\content-copy.txt" CopyToOutputDirectory="PreserveNewest" />
     <None Include="none-with-packagepath.txt" PackagePath="build\%(Filename)%(Extension)" />
     <Content Include="content-with-packagepath.txt" PackagePath="build\%(Filename)%(Extension)" />
@@ -50,7 +50,7 @@
   </ItemGroup>
 	<Target Name="RemoveContent" Condition="'$(RemoveContent)' == 'true'" BeforeTargets="GetPackageContents">
 		<ItemGroup>
-			<PackageFile Remove="@(PackageFile)" Condition="'%(Kind)' == 'Content' Or '%(Kind)' == 'None'" />
+			<PackageFile Remove="@(PackageFile)" Condition="'%(PackFolder)' == 'content' Or '%(PackFolder)' == 'none'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/NuGetizer.Tests/Scenarios/given_a_packaging_project/a.nuproj
+++ b/src/NuGetizer.Tests/Scenarios/given_a_packaging_project/a.nuproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 	<Target Name="_AugmentMetadata" BeforeTargets="GetPackageContents">
 		<ItemGroup>
-			<PackageFile Condition="'%(PackageFile.Kind)' == 'Metadata'">
+			<PackageFile Condition="'%(PackageFile.PackFolder)' == 'Metadata'">
 				<Foo>Bar</Foo>
 			</PackageFile>
 		</ItemGroup>

--- a/src/NuGetizer.Tests/TargetsTests.cs
+++ b/src/NuGetizer.Tests/TargetsTests.cs
@@ -20,7 +20,7 @@ namespace NuGetizer
 		{
 			var project = new Project("NuGetizer.targets", new Dictionary<string, string>
 			{
-				{ "BuildOutputKind", "build" }
+				{ "PackFolder", "build" }
 			}, null);
 
 			Assert.NotEqual("true", project.GetPropertyValue("PackFrameworkReferences"));
@@ -31,7 +31,7 @@ namespace NuGetizer
 		{
 			var project = new Project("NuGetizer.targets", new Dictionary<string, string>
 			{
-				{ "BuildOutputKind", "tool" }
+				{ "PackFolder", "tool" }
 			}, null);
 
 			Assert.NotEqual("true", project.GetPropertyValue("PackFrameworkReferences"));
@@ -42,7 +42,7 @@ namespace NuGetizer
 		{
 			var project = new Project("NuGetizer.targets", new Dictionary<string, string>
 			{
-				{ "BuildOutputKind", "tools" }
+				{ "PackFolder", "tools" }
 			}, null);
 
 			Assert.NotEqual("true", project.GetPropertyValue("PackFrameworkReferences"));
@@ -53,7 +53,7 @@ namespace NuGetizer
 		{
 			var project = new Project("NuGetizer.targets", new Dictionary<string, string>
 			{
-				{ "BuildOutputKind", "lib" }
+				{ "PackFolder", "lib" }
 			}, null);
 
 			Assert.Equal("true", project.GetPropertyValue("PackFrameworkReferences"));
@@ -113,7 +113,7 @@ namespace NuGetizer
 
 			Assert.DoesNotContain(items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
 				Identity = "NuGetizer",
 			}));
 		}

--- a/src/NuGetizer.Tests/given_a_complex_pack.cs
+++ b/src/NuGetizer.Tests/given_a_complex_pack.cs
@@ -58,13 +58,13 @@ namespace NuGetizer
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
 				Filename = "A",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Identity = "B",
-				Kind = "Dependency",
+                PackFolder = PackFolderKind.Dependency,
 				Version = "2.0.0",
 			}));
 		}
@@ -94,13 +94,13 @@ namespace NuGetizer
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
 				Filename = "B",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Identity = "C",
-				Kind = "Dependency",
+                PackFolder = PackFolderKind.Dependency,
 				Version = "3.0.0",
 			}));
 		}
@@ -122,13 +122,13 @@ namespace NuGetizer
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
 				Filename = "C",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Identity = "Foo",
-				Kind = "Dependency",
+                PackFolder = PackFolderKind.Dependency,
 				Version = "1.0.0",
 			}));
 		}
@@ -144,14 +144,14 @@ namespace NuGetizer
 			{
 				Filename = "d",
 				Extension = ".dll",
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 				PackagePath = "",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Filename = "d",
 				Extension = ".xml",
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 				PackagePath = "",
 			}));
 		}

--- a/src/NuGetizer.Tests/given_a_framework_library.cs
+++ b/src/NuGetizer.Tests/given_a_framework_library.cs
@@ -23,7 +23,7 @@ namespace NuGetizer
             Assert.Contains(result.Items, item => item.Matches(new
             {
                 Identity = "PresentationCore",
-                Kind = PackageItemKind.FrameworkReference,
+                PackFolder = PackFolderKind.FrameworkReference,
             }));
         }
 
@@ -39,7 +39,7 @@ namespace NuGetizer
             Assert.DoesNotContain(result.Items, item => item.Matches(new
             {
                 Identity = "PresentationCore",
-                Kind = PackageItemKind.FrameworkReference,
+                PackFolder = PackFolderKind.FrameworkReference,
             }));
         }
     }

--- a/src/NuGetizer.Tests/given_a_library_with_private_assets_reference.cs
+++ b/src/NuGetizer.Tests/given_a_library_with_private_assets_reference.cs
@@ -22,12 +22,12 @@ namespace NuGetizer
 
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
 				Identity = "Mono.Options",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 				Filename = "Mono.Options",
 				NuGetSourceType = "Package",
 				NuGetPackageId = "Mono.Options",
@@ -46,12 +46,12 @@ namespace NuGetizer
 
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
 				Identity = "Newtonsoft.Json",
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 				Filename = "Newtonsoft.Json",
 				NuGetSourceType = "Package",
 				NuGetPackageId = "Newtonsoft.Json",
@@ -70,12 +70,12 @@ namespace NuGetizer
 
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
 				Identity = "xunit",
 			}));
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 				Filename = "xunit",
 				NuGetSourceType = "Package",
 				NuGetPackageId = "xunit",

--- a/src/NuGetizer.Tests/given_a_library_with_project_reference.cs
+++ b/src/NuGetizer.Tests/given_a_library_with_project_reference.cs
@@ -23,8 +23,8 @@ namespace NuGetizer
 			result.AssertSuccess(output);
 
 			// TODO: build some helpers to make this easier to assert.
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include main project output as Library");
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include referenced project output as Library");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("PackFolder") == PackFolderKind.Lib), "Did not include main project output as Library");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".dll" && i.GetMetadata("PackFolder") == PackFolderKind.Lib), "Did not include referenced project output as Library");
 		}
 
 		[Fact]
@@ -35,8 +35,8 @@ namespace NuGetizer
 			result.AssertSuccess(output);
 
 			// TODO: build some helpers to make this easier to assert.
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include main project symbols");
-			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("Kind") == PackageItemKind.Lib), "Did not include referenced project symbols");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "a" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("PackFolder") == PackFolderKind.Lib), "Did not include main project symbols");
+			Assert.True(result.Items.Any(i => i.GetMetadata("FileName") == "b" && i.GetMetadata("Extension") == ".pdb" && i.GetMetadata("PackFolder") == PackFolderKind.Lib), "Did not include referenced project symbols");
 		}
 
 		[Fact]
@@ -51,8 +51,8 @@ namespace NuGetizer
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
 				Filename = "b", 
-				Extension = ".dll", 
-				Kind = "Lib",
+				Extension = ".dll",
+                PackFolder = "lib",
 			}));
 		}
 
@@ -73,7 +73,7 @@ namespace NuGetizer
 			{
 				Filename = "b",
 				Extension = ".dll",
-				Kind = "Lib",
+                PackFolder = "lib",
 			}));
 		}
 	}

--- a/src/NuGetizer.Tests/given_a_multitargeting_library.cs
+++ b/src/NuGetizer.Tests/given_a_multitargeting_library.cs
@@ -14,7 +14,6 @@ namespace NuGetizer
                 .AssertSuccess(output);
         }
 
-		
         [Fact]
 		public void when_gettingcontents_then_includes_content_from_all_frameworks()
 		{
@@ -40,7 +39,7 @@ namespace NuGetizer
 
             Assert.Single(result.Items, item => item.Matches(new
             {
-                Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
                 TargetFrameworkMoniker = "",
             }));
         }
@@ -63,7 +62,7 @@ namespace NuGetizer
 
             Assert.Single(result.Items, item => item.Matches(new
             {
-                Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
                 NewMetadata = "Foo",
             }));
         }
@@ -80,7 +79,7 @@ namespace NuGetizer
 
             Assert.Single(result.Items, item => item.Matches(new
             {
-                Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
                 Description = "Customized",
                 LicenseExpression = "MIT",
             }));

--- a/src/NuGetizer.Tests/given_a_packaging_project.cs
+++ b/src/NuGetizer.Tests/given_a_packaging_project.cs
@@ -44,7 +44,7 @@ namespace NuGetizer
 
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = "Metadata",
+                PackFolder = PackFolderKind.Metadata,
 				Foo = "Bar",
 			}));
 		}
@@ -101,7 +101,7 @@ namespace NuGetizer
 
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = "Dependency",
+                PackFolder = PackFolderKind.Dependency,
 				Identity = "E",
 			}));
 		}

--- a/src/NuGetizer.Tests/given_an_empty_library.cs
+++ b/src/NuGetizer.Tests/given_an_empty_library.cs
@@ -24,8 +24,8 @@ namespace NuGetizer
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Extension = ".dll",
-				Kind = "Lib"
-			}));
+                PackFolder = PackFolderKind.Lib
+            }));
 		}
 
 		[Fact]
@@ -40,8 +40,8 @@ namespace NuGetizer
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
 				Extension = ".dll",
-				Kind = "Lib"
-			}));
+                PackFolder = PackFolderKind.Lib
+            }));
 		}
 
 		[Fact]
@@ -96,7 +96,7 @@ namespace NuGetizer
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Extension = ".xml",
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 			}));
 		}
 
@@ -112,7 +112,7 @@ namespace NuGetizer
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
 				Extension = ".xml",
-				Kind = PackageItemKind.Lib,
+                PackFolder = PackFolderKind.Lib,
 			}));
 		}
 
@@ -144,7 +144,7 @@ namespace NuGetizer
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
 				Identity = "PresentationFramework",
-				Kind = PackageItemKind.FrameworkReference,
+                PackFolder = PackFolderKind.FrameworkReference,
 			}));
 		}
 
@@ -161,7 +161,7 @@ namespace NuGetizer
 			Assert.DoesNotContain(result.Items, item => item.Matches(new
 			{
 				Identity = "System.Core",
-				Kind = PackageItemKind.FrameworkReference,
+                PackFolder = PackFolderKind.FrameworkReference,
 			}));
 		}
 

--- a/src/NuGetizer.Tests/given_duplicate_package_files.cs
+++ b/src/NuGetizer.Tests/given_duplicate_package_files.cs
@@ -32,22 +32,22 @@ namespace NuGetizer
 
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.None,
+                PackFolder = PackFolderKind.None,
 				PackagePath = @"content\a\1\content.txt"
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.None,
+                PackFolder = PackFolderKind.None,
 				PackagePath = @"content\a\2\content.txt"
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.None,
+                PackFolder = PackFolderKind.None,
 				PackagePath = @"content\b\1\content.txt"
 			}));
 			Assert.Contains(result.Items, item => item.Matches(new
 			{
-				Kind = PackageItemKind.None,
+                PackFolder = PackFolderKind.None,
 				PackagePath = @"content\b\2\content.txt"
 			}));
 

--- a/src/NuGetizer.Tests/given_packagereferences.cs
+++ b/src/NuGetizer.Tests/given_packagereferences.cs
@@ -138,7 +138,7 @@ namespace NuGetizer
   <PropertyGroup>
     <PackageId>Library</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <BuildOutputKind>build</BuildOutputKind>
+    <PackFolder>build</PackFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include='Microsoft.Build.Tasks.Core' Version='16.6.0' />
@@ -150,7 +150,7 @@ namespace NuGetizer
             Assert.DoesNotContain(result.Items, item => item.Matches(new
             {
                 Identity = "Microsoft.Build.Tasks.Core",
-                Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
             }));
         }
 
@@ -162,7 +162,7 @@ namespace NuGetizer
   <PropertyGroup>
     <PackageId>Library</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <BuildOutputKind>build</BuildOutputKind>
+    <PackFolder>build</PackFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include='Microsoft.Build.Tasks.Core' Version='16.6.0' Pack='true' />
@@ -174,7 +174,7 @@ namespace NuGetizer
             Assert.Contains(result.Items, item => item.Matches(new
             {
                 Identity = "Microsoft.Build.Tasks.Core",
-                Kind = PackageItemKind.Dependency,
+                PackFolder = PackFolderKind.Dependency,
             }));
         }
 

--- a/src/NuGetizer.Tests/given_packinference.cs
+++ b/src/NuGetizer.Tests/given_packinference.cs
@@ -43,7 +43,7 @@ namespace NuGetizer
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <None Include='Library.props' Kind='build' />
+    <None Include='Library.props' PackFolder='build' />
   </ItemGroup>
 </Project>",
                 "GetPackageContents", output);
@@ -66,7 +66,7 @@ namespace NuGetizer
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <None Include='Library.props' Kind='build' FrameworkSpecific='true' />
+    <None Include='Library.props' PackFolder='build' FrameworkSpecific='true' />
   </ItemGroup>
 </Project>",
                 "GetPackageContents", output);
@@ -136,7 +136,7 @@ namespace NuGetizer
     <PackContent>false</PackContent>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include='Library.props' Kind='build' />
+    <Content Include='Library.props' PackFolder='build' />
   </ItemGroup>
 </Project>",
                 "GetPackageContents", output);
@@ -326,7 +326,7 @@ namespace NuGetizer
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include='Pack.cs' Pack='true' Kind='content' CodeLanguage='%(Extension)' />
+    <Compile Include='Pack.cs' Pack='true' PackFolder='content' CodeLanguage='%(Extension)' />
     <Compile Include='NonPack.cs' />
   </ItemGroup>
 </Project>",
@@ -503,7 +503,7 @@ namespace NuGetizer
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Data>
-        <Kind>content</Kind>
+        <PackFolder>content</PackFolder>
         <Pack>true</Pack>
         <BuildAction>Data</BuildAction>
         <CopyToOutput>true</CopyToOutput>

--- a/src/dotnet-nugetize/Program.cs
+++ b/src/dotnet-nugetize/Program.cs
@@ -79,7 +79,7 @@ namespace NuGetize
 
                 var dependencies = items.Root.Descendants("PackageContent")
                     .Where(x =>
-                        "Dependency".Equals(x.Element("Kind")?.Value, StringComparison.OrdinalIgnoreCase) &&
+                        "Dependency".Equals(x.Element("PackFolder")?.Value, StringComparison.OrdinalIgnoreCase) &&
                         x.Element("PackageId")?.Value == packageId)
                     .ToList();
 


### PR DESCRIPTION
Kind as metadata for an item does not look very idiomatic. Since every other property and metadata starts with `Pack`, this renames it to `PackFolder`. The `PackFolderKind` items define the defaults now.

The compatiblity targets were extended to account for the now-legacy values from previous releases as well as the pre-fork nugetizer.

Update the docs accordingly too.