### PR TITLE
Make sure we never get duplicate NuspecFile items

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -237,10 +237,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Returns="@(_PackageTargetPath)" Condition="'$(IsPackable)' == 'true'">
     <MakeDir Directories="$(PackageOutputPath)" Condition="!Exists('$(PackageOutputPath)')" />
-    <ItemGroup>
+    <ItemGroup Condition="'@(NuspecFile)' == ''">
       <NuspecFile Include="$(NuspecFile)" />
     </ItemGroup>
-    <CreatePackage Manifest="@(PackageTargetPath)" NuspecFile="@(NuspecFile -> '%(FullPath)')" Contents="@(_PackageContent)" 
+    <PropertyGroup>
+      <_NuspecFile>%(NuspecFile.FullPath)</_NuspecFile>
+    </PropertyGroup>
+    <CreatePackage Manifest="@(PackageTargetPath)" NuspecFile="$(_NuspecFile)" Contents="@(_PackageContent)" 
                    EmitPackage="$(EmitPackage)" EmitNuspec="$(EmitNuspec)"
                    TargetPath="@(PackageTargetPath->'%(FullPath)')">
       <Output TaskParameter="OutputPackage" ItemName="_PackageTargetPath" />

--- a/src/NuGetizer.Tasks/dotnet-nugetize.targets
+++ b/src/NuGetizer.Tasks/dotnet-nugetize.targets
@@ -14,11 +14,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="CopyFilesToOutputDirectory" />
 
   <Target Name="_WritePackageContents" Condition="'$(dotnet-nugetize)' != ''" AfterTargets="GetPackageContents">
-    <ItemGroup>
+    <ItemGroup Condition="'@(NuspecFile)' == ''">
       <NuspecFile Include="$(NuspecFile)" />
-    </ItemGroup>    
+    </ItemGroup>
+    <PropertyGroup>
+      <_NuspecFile>%(NuspecFile.FullPath)</_NuspecFile>
+    </PropertyGroup>
     <ItemGroup>
-      <PackageMetadata Update="@(PackageMetadata)" Nuspec="@(NuspecFile -> '%(FullPath)')" NuPkg="@(PackageTargetPath)" />
+      <PackageMetadata Update="@(PackageMetadata)" Nuspec="$(_NuspecFile)" NuPkg="@(PackageTargetPath)" />
       <PackageContent Include="@(_PackageContent)" Exclude="@(PackageMetadata)" />
     </ItemGroup>
     <WriteItemsToFile Condition="'@(PackageMetadata)' != ''" Overwrite="false" Items="@(PackageMetadata)" ItemName="PackageMetadata" File="$(dotnet-nugetize)" />


### PR DESCRIPTION
This was breaking when using dotnet-nugetize.