### PR TITLE
Add support for Microsoft.Build.NoTargets SDK

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.props
@@ -1,0 +1,16 @@
+﻿<!--
+***********************************************************************************************
+NuGetizer.Authoring.NoTargets.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CustomAfterNoTargets>$(MSBuildThisFileDirectory)NuGetizer.Authoring.NoTargets.targets</CustomAfterNoTargets>
+  </PropertyGroup>
+</Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.targets
@@ -1,0 +1,30 @@
+﻿<!--
+***********************************************************************************************
+NuGetizer.Authoring.NoTargets.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--NOTE: the NoTargets SDK overwrites this target with a blank one, breaking the P2P reference 
+      for NuGetizer. We bring it back to allow this again. -->
+  <Target Name="GetTargetPathWithTargetPlatformMoniker" 
+          BeforeTargets="GetTargetPath" 
+          DependsOnTargets="$(GetTargetPathWithTargetPlatformMonikerDependsOn)" 
+          Returns="@(TargetPathWithTargetPlatformMoniker)">
+    <ItemGroup>
+      <TargetPathWithTargetPlatformMoniker Include="$(TargetPath)">
+        <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
+        <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(TargetFrameworkVersion.TrimStart('vV'))</TargetFrameworkVersion>
+      </TargetPathWithTargetPlatformMoniker>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.props
@@ -54,4 +54,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuildProjectReferences Condition="'$(BuildProjectReferences)' == ''">true</BuildProjectReferences>
   </PropertyGroup>
 
+  <Import Project="NuGetizer.Authoring.NoTargets.props" Condition="'$(UsingMicrosoftNoTargetsSdk)' == 'true'"/>
+  
 </Project>

--- a/src/NuGetizer.Tests/given_a_notargets_sdk_project.cs
+++ b/src/NuGetizer.Tests/given_a_notargets_sdk_project.cs
@@ -1,0 +1,108 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetizer
+{
+    public class given_a_notargets_sdk_project
+    {
+        ITestOutputHelper output;
+
+        public given_a_notargets_sdk_project(ITestOutputHelper output) => this.output = output;
+
+        [Fact]
+        public void cam_reference_packaging_project()
+        {
+            var result = Builder.BuildProjects(
+                "GetPackageContents", output, null,
+                ("main.msbuildproj", @"
+<Project Sdk='Microsoft.Build.NoTargets/2.0.1'>
+  <PropertyGroup>
+    <PackageId>Foo</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Newtonsoft.Json' Version='12.0.3' />
+    <ProjectReference Include='other.msbuildproj' />
+  </ItemGroup>
+</Project>"), 
+                ("other.msbuildproj", @"
+<Project Sdk='Microsoft.Build.NoTargets/2.0.1'>
+  <PropertyGroup>
+    <PackageId>Bar</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Castle.Core' Version='4.4.1' />
+  </ItemGroup>
+</Project>"));
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Foo",
+                PackFolder = PackFolderKind.Metadata
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Newtonsoft.Json",
+                PackFolder = PackFolderKind.Dependency
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Bar",
+                PackFolder = PackFolderKind.Dependency
+            }));
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Castle.Core",
+                PackageId = "Foo",
+                PackFolder = PackFolderKind.Dependency
+            }));
+        }
+
+        [Fact]
+        public void cam_be_referenced()
+        {
+            var result = Builder.BuildProjects(
+                "GetPackageContents", output, null,
+                ("main.csproj", @"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <PackageId>Foo</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include='other.msbuildproj' />
+  </ItemGroup>
+</Project>"),
+                ("other.msbuildproj", @"
+<Project Sdk='Microsoft.Build.NoTargets/2.0.1'>
+  <PropertyGroup>
+    <PackageId>Bar</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Castle.Core' Version='4.4.1' />
+  </ItemGroup>
+</Project>"));
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Foo",
+                PackFolder = PackFolderKind.Metadata
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Bar",
+                PackFolder = PackFolderKind.Dependency
+            }));
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Castle.Core",
+                PackageId = "Foo",
+                PackFolder = PackFolderKind.Dependency
+            }));
+        }
+    }
+}


### PR DESCRIPTION
This allows using that SDK for packaging projects if desired. This change allows referencing such projects from other packaging projects, and also from regular Microsoft.NET.Sdk projects too.