### PR TITLE
Import compatibility props for multi-targeting too

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -14,6 +14,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="NuGetizer.Tasks.CreatePackage" AssemblyFile="NuGetizer.Tasks.dll" />
 
+  <!-- Adds compatibility targets with Pack SDK -->
+  <Import Project="NuGetizer.Compatibility.props" />
+
   <PropertyGroup>
     <!-- Whether to infer package contents -->
     <EnablePackInference Condition="'$(EnablePackInference)' == ''">true</EnablePackInference>

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -14,8 +14,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGetizer.Tasks.WriteItemsToFile" AssemblyFile="NuGetizer.Tasks.dll" />
 
   <Import Project="NuGetizer.props" Condition="'$(NuGetizerPropsImported)' == ''" />
-  <!-- Adds compatibility targets with Pack SDK -->
-  <Import Project="NuGetizer.Compatibility.props" />
   <Import Project="NuGetizer.Shared.targets" />
 
   <!-- We don't need to do the inference in the crosstargeting scenario, we'd infer in the inner build instead -->


### PR DESCRIPTION
Because we were importing the compatibility props only from the non-multitargeting targets, the defaulting of PackOnBuild from GeneratePackageOnBuild was not being applied and that caused usage of that property to fail in multi-targeting projects.

By bringing in the compat props from the shared targets (used in both single and multi targeting scenarios), we can properly default all values in all types of builds.

Fixes #34