### PR TITLE
When resolving P2P references for packaging, set target framework

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -152,6 +152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
              BuildInParallel="$(BuildInParallel)"
              Properties="%(_NuGetizedProjectReference.SetConfiguration); 
                          %(_NuGetizedProjectReference.SetPlatform); 
+                         %(_NuGetizedProjectReference.SetTargetFramework); 
                          BuildingPackage=$(BuildingPackage); 
                          DesignTimeBuild=false"
              Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
@@ -232,7 +233,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
              Targets="GetTargetPathWithTargetPlatformMoniker"
              BuildInParallel="$(BuildInParallel)"
-             Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+             Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); 
+                         %(_MSBuildProjectReferenceExistent.SetPlatform);
+                         %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
              RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectTargetPath" />
     </MSBuild>

--- a/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/common.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/common.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uilibrary.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uilibrary.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="uishared.csproj" />
+    <ProjectReference Include="common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uishared.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uishared.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/given_multitargeting_libraries.cs
+++ b/src/NuGetizer.Tests/given_multitargeting_libraries.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetizer
+{
+    public class given_multitargeting_libraries
+    {
+        ITestOutputHelper output;
+
+        public given_multitargeting_libraries(ITestOutputHelper output) => this.output = output;
+
+        [InlineData("common.csproj")]
+        [InlineData("uilibrary.csproj")]
+        [InlineData("uishared.csproj")]
+        [Theory]
+        public void when_packing_on_build_then_succeeds(string projectName)
+        {
+            Builder.BuildScenario(
+                nameof(given_multitargeting_libraries),
+                projectName: projectName, target: "Restore", output: output)
+                .AssertSuccess(output);
+
+            Builder.BuildScenario(
+                nameof(given_multitargeting_libraries),
+                projectName: projectName, target: "Build", output: output)
+                .AssertSuccess(output);
+
+            var result = Builder.BuildScenario(
+                nameof(given_multitargeting_libraries),
+                projectName: projectName,
+                target: "GetPackageTargetPath", output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Single(result.Items);
+
+            Assert.True(File.Exists(result.Items[0].GetMetadata("FullPath")));
+        }
+    }
+}


### PR DESCRIPTION
When MSBuild project references are resolved, in multi-targeting P2P references, the `SetTargetFramework` metadata is populated with the nearest target framework supported by the referenced project (from the referencing project's point of view). For example, if a `netcore3.1` project references a `net5.0;netstandard2.1` one, when resolving the contents for the referenced project, the built-in targets will properly calculate (using the NuGet-provided GetReferenceNearestTargetFrameworkTask task) the target framework compatible with the referencing project.

If we don't set the target framework, we end up inadvertently invoking targets on the project reference using the *calling* project target framework (in this case `netcoreapp3.1`), which is not supported by the referenced project and we end up with a missing MSBuild target import (since NuGet conditions the .props/.targets imports to the target framework), and it ends up manifesting itself as an error that the reference hasn't been nugetized, when in fact it's because we're invoking with the wrong TF.

Fixes #27.