### PR TITLE
Add more common GetTargetPath to multi-targeting

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
@@ -16,6 +16,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GetNativeManifest" />
   <Target Name="GetCopyToOutputDirectoryItems" />
 
+
+  <!--
+  ============================================================
+  GetTargetPath
+
+  When cross-targeting and the authoring project references a 
+  nugetized library, return all the determined target paths.
+  ============================================================
+  -->
+  <Target Name="GetTargetPath" Returns="@(TargetPathWithTargetPlatformMoniker)" />
+
   <!--
   ============================================================
   GetTargetPathWithTargetPlatformMoniker
@@ -27,6 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker"
           DependsOnTargets="_ComputeTargetFrameworkItems"
+          BeforeTargets="GetTargetPath"
           Returns="@(TargetPathWithTargetPlatformMoniker)">
 
     <MSBuild Projects="@(_InnerBuildProjects)"

--- a/src/NuGetizer.Tests/given_a_multitargeting_library.cs
+++ b/src/NuGetizer.Tests/given_a_multitargeting_library.cs
@@ -85,5 +85,15 @@ namespace NuGetizer
             }));
         }
 
+        [Fact]
+        public void when_getting_target_path_then_includes_all_frameworks()
+        {
+            var result = Builder.BuildScenario(
+                nameof(given_a_multitargeting_library), target: "GetTargetPath", output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Equal(2, result.Items.Length);
+        }
     }
 }


### PR DESCRIPTION
We already add `GetTargetPathWithTargetPlatformMoniker` for multi-targeting, but `GetTargetPath` is probably more common, so we add it with the same pattern used in the built-in targets.