### PR TITLE
When using PackageReference metadata infer Pack=true

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -111,8 +111,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <InferenceCandidate>
       <DefaultPackFolder />
       <Pack />
-      <PackagePath />
       <PackFolder />
+      <PackagePath />
+      <PackageReference />
       <ShouldPack />
       <TargetPath />
     </InferenceCandidate>
@@ -177,7 +178,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <InferenceCandidate Include="@(%(PackInference.Identity))" Exclude="@(%(PackInference.Identity) -> '%(PackExclude)')"/>
       <InferenceCandidate>
-        <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(PackFolder)' != '') and '%(Pack)' != 'false'">true</ShouldPack>
+        <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(PackFolder)' != '' or '%(PackageReference)' != '') and '%(Pack)' != 'false'">true</ShouldPack>
       </InferenceCandidate>
       <!-- No need to re-assign a target path if the item already provides one. We do this because otherwise the built-in AssignTargetPath 
            task unconditionally re-sets it. See https://github.com/dotnet/msbuild/blob/master/src/Tasks/AssignTargetPath.cs -->

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -554,5 +554,50 @@ namespace NuGetizer
             }));
         }
 
+        [Fact]
+        public void when_packing_none_with_packagereference_then_includes_it()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Newtonsoft.Json' Version='12.0.3' />
+    <None Include='lib\netstandard2.0\Newtonsoft.Json.dll' PackageReference='Newtonsoft.Json' /> 
+  </ItemGroup>
+</Project>", output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib\\netstandard2.0\\Newtonsoft.Json.dll"
+            }));
+        }
+
+        [Fact]
+        public void when_packing_none_with_packagereference_then_can_change_package_path()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Newtonsoft.Json' Version='12.0.3' />
+    <None Include='lib\netstandard2.0\Newtonsoft.Json.dll' PackageReference='Newtonsoft.Json' PackagePath='build\%(Filename)%(Extension)' /> 
+  </ItemGroup>
+</Project>", output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "build\\Newtonsoft.Json.dll"
+            }));
+        }
     }
 }


### PR DESCRIPTION
This makes it behave just like PackagePath/PackFolder, and avoids having to explicitly add `Pack=true` after you specified `PackageReference`.

For example:

    <None Include='lib\netstandard2.0\Newtonsoft.Json.dll' PackageReference='Newtonsoft.Json' />

Will now automatically be packed. The existing inference rules about target path/package path still apply, and in this case it will mean the file is packed to the same relative path as the referenced file in the source package reference.

Fixes #44